### PR TITLE
Exclude Non-Shinies

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,6 +23,7 @@ $shinyStats = $db->select('pokemon_shiny_stats', [
     'count' => Medoo::raw('SUM(`count`)')
 ], [
     'date' => $today,
+    'count[>]' => 0,
     'GROUP' => 'pokemon_id'
 ]);
 


### PR DESCRIPTION
Adjust the db query to only include identified shinies. Non-shiny mon will no longer be included.

This didn't use to happen, right? I think it was a recent Golbat change.